### PR TITLE
Log Krisp auth errors, throttle errors

### DIFF
--- a/Sources/LiveKitKrispNoiseFilter/LiveKitKrispNoiseFilter.swift
+++ b/Sources/LiveKitKrispNoiseFilter/LiveKitKrispNoiseFilter.swift
@@ -33,7 +33,7 @@ public class LiveKitKrispNoiseFilter {
 
         // Throttle high-frequency errors to avoid spamming the console
         errorSubject
-            .throttle(for: .seconds(15), scheduler: DispatchQueue.main, latest: true)
+            .throttle(for: .seconds(60), scheduler: DispatchQueue.main, latest: true)
             .sink { message in
                 print(message)
             }


### PR DESCRIPTION
We were seeing an extremely high volume of `LiveKitKrispNoiseFilter Process failed, channel: 0` errors if you were using Krisp with a local instance where it wasn't disabled (possibly only since https://github.com/livekit/krisp-noise-filter/pull/92/files#diff-4ed588afa2fc7d7192ee9658c0fee6aa5270d646c9e1a7ad5aee1711a16babbaL178 but I haven't confirmed). This was confusing and annoying.

This change explicitly checks the auth status and logs a helpful error message. I've also added a throttler so these will log only once per minute. I think it's better to keep them logging occasionally so people see them while in use rather than logging only at startup but I don't know if that's right. We could also add the logging to the underlying KrispNoiseFilter class from the framework, where the auth actually happens, if we wanted to but it was easier to add here.