### PR TITLE
Add licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+Please see https://livekit.io/legal/terms-of-service for the LiveKit Cloud Terms of Service.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Krisp Noise Filter for LiveKit Swift SDK
+
+This is a feature of LiveKit Cloud and is subject to the LiveKit Cloud [Terms of Service](https://livekit.io/legal/terms-of-service).


### PR DESCRIPTION
this seems to be the best way to note the license here, as package.swift has no spot for it.